### PR TITLE
V1.1.6

### DIFF
--- a/models/eng/config.ini
+++ b/models/eng/config.ini
@@ -84,6 +84,8 @@ question_mark=/^\?$/
 # Markables forbidden to have antecedents - semicolon separated patterns of initial (^x), final ($x) or head(@x) POS + text that rule out antecedent. 
 # Use ! for negation, & for multiple criteria
 no_antecedent=@NNS/.*&^!(DT|PR?P\$)/.*
+# Are indefinite markables allowed to be anaphors (i.e. can they have antecedents)?
+allow_indef_anaphor=False
 
 ### Agreement Class Detection ###
 pos_agree_mapping=NPS>plural;NNPS>plural;NNS>plural

--- a/modules/xrenner_classes.py
+++ b/modules/xrenner_classes.py
@@ -4,6 +4,7 @@ Basic classes for parsed tokens, markables and sentences.
 Author: Amir Zeldes
 """
 
+import sys
 
 class ParsedToken:
 	def __init__(self, tok_id, text, lemma, pos, morph, head, func, sentence, modifiers, child_funcs, child_strings, lex, quoted=False):
@@ -65,10 +66,16 @@ class Sentence:
 		self.mood = mood
 
 
-def get_descendants(parent, children_dict):
+def get_descendants(parent, children_dict, seen_tokens, sent_num, conll_tokens):
 	my_descendants = []
 	my_descendants += children_dict[parent]
 	for child in children_dict[parent]:
+		if child in seen_tokens:
+			sys.stderr.write("\nCycle detected in syntax tree in sentence " + str(sent_num) + " (child of token: '" + conll_tokens[int(parent)].text + "')\n")
+			sys.exit("Exiting due to invalid input\n")
+		else:
+			seen_tokens += [child]
+	for child in children_dict[parent]:
 		if child in children_dict:
-			my_descendants += get_descendants(child, children_dict)
+			my_descendants += get_descendants(child, children_dict, seen_tokens, sent_num, conll_tokens)
 	return my_descendants

--- a/modules/xrenner_coref.py
+++ b/modules/xrenner_coref.py
@@ -44,7 +44,7 @@ def search_prev_markables(markable, previous_markables, rule, lex, max_dist, pro
 										if propagate.startswith("propagate"):
 											propagate_entity(markable, candidate, propagate)
 										return candidate
-								elif markable.entity == candidate.entity and (isa(markable, candidate, lex) or isa(candidate, markable, lex)) and agree_compatible(markable, candidate, lex):
+								elif markable.entity == candidate.entity and (isa(markable, candidate, lex) or isa(candidate, markable, lex)):
 									if modifiers_compatible(markable, candidate, lex) and modifiers_compatible(candidate, markable, lex):
 										if propagate.startswith("propagate"):
 											propagate_entity(markable, candidate, propagate)
@@ -55,7 +55,7 @@ def search_prev_markables(markable, previous_markables, rule, lex, max_dist, pro
 										if propagate.startswith("propagate"):
 											propagate_entity(markable, candidate, propagate)
 										return candidate
-								elif entities_compatible(markable, candidate, lex) and (isa(markable, candidate, lex) or isa(candidate, markable, lex)) and agree_compatible(markable, candidate, lex):
+								elif entities_compatible(markable, candidate, lex) and (isa(markable, candidate, lex) or isa(candidate, markable, lex)):
 										if modifiers_compatible(markable, candidate, lex) and modifiers_compatible(candidate, markable, lex):
 											if merge_entities(markable, candidate, previous_markables, lex):
 												if propagate.startswith("propagate"):


### PR DESCRIPTION
- Added punctuation extension to envelope markables
- Added parameter allow_indef_anaphor to control whether indefinites can have antecdedents
- Check for cycles in input syntax trees ( closes #7 )
- Support for isa relation between morphologically disagreeing items if inflected forms explicitly listed
